### PR TITLE
Added example on handling an expected 404 error

### DIFF
--- a/examples/angular-tour-of-heroes/src/app/hero.service.ts
+++ b/examples/angular-tour-of-heroes/src/app/hero.service.ts
@@ -95,10 +95,18 @@ export class HeroService {
    */
   private handleError<T>(operation = 'operation', result?: T) {
     return (error: any): Observable<T> => {
-      // TODO: send the error to remote logging infrastructure
+      // // Example: What if we are expecting errors of a certain status and we don't want them appearing in our console?
+      // if (error.status === 404) {
+      //   console.log(`All good. We've handled an expected 404 error`);
+      //   // Alternatively, you can just throw a new error here
+      //   // throw new Error(`This one's on you - fix it 🤣 ${JSON.stringify(error, null, 2)}`);
+      // }
+      // // console.log(`Blerk! This won't display if we throw a new Error above, though.`);
+
+      // TODO: We probably want to do something other than log an error in our console, but this works for now
       console.error(error); // log to console instead
 
-      // TODO: better job of transforming error for user consumption
+      // TODO: Implement a better way to convey this error to the user instead of simply adding it to a raw display of messages
       this.log(`${operation} failed: ${error.message}`);
 
       // Let the app keep running by returning an empty result.


### PR DESCRIPTION
This was a simple example showing how we can handle an error from our Observables and either quietly handle it as expected, or pound the alarm and throw an error:

Here's an example handling an expected `404` error:
<img width="1268" alt="Screen Shot 2019-11-11 at 15 10 21 PM" src="https://user-images.githubusercontent.com/4030490/68628546-c467da00-0495-11ea-8c08-0a4402cdeb8f.png">

Here's an example where we are handling an expected `404` error, but we want to throw an error. In this case, the error is unhandled and appears in the JavaScript console:
<img width="1312" alt="Screen Shot 2019-11-11 at 15 11 06 PM" src="https://user-images.githubusercontent.com/4030490/68628547-c467da00-0495-11ea-970c-16f8cfeee8a7.png">
